### PR TITLE
power_shamu.c : Remove logspam on touchboost

### DIFF
--- a/power/power_shamu.c
+++ b/power/power_shamu.c
@@ -174,9 +174,6 @@ static void touch_boost()
     snprintf(data, MAX_LENGTH, "1:%d", client);
     rc = sendto(client_sockfd, data, strlen(data), 0,
         (const struct sockaddr *)&client_addr, sizeof(struct sockaddr_un));
-    if (rc < 0) {
-        ALOGE("%s: failed to send: %s", __func__, strerror(errno));
-    }
 }
 
 static void low_power(int on)


### PR DESCRIPTION
This case should rarely happen if never and if it happen it's not necessay to have more than 100lines of log per sec for a such non problematic issue.
Also if you run an other cpu governor than default one (through an other kernel for exemple) touchboost will not work but won't cause any issue.
i've tested it and it cause no problem and make log clear to read.
